### PR TITLE
Add threshholded variants

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+Jacob Moorman
+William Swartworth
+Yotam Yaniv

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -12,4 +12,4 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 
 
 from ._abc import Base
-from ._variants import Cyclic, MaxDistance, Random, SVRandom, UniformRandom, Quantile, SampledQuantile
+from ._variants import Cyclic, MaxDistance, Random, SVRandom, UniformRandom, Quantile, SampledQuantile, WindowedQuantile

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -12,4 +12,4 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 
 
 from ._abc import Base
-from ._variants import Cyclic, MaxDistance, Random, SVRandom, UniformRandom
+from ._variants import Cyclic, MaxDistance, Random, SVRandom, UniformRandom, Quantile, SampledQuantile

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -12,4 +12,13 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 
 
 from ._abc import Base
-from ._variants import Cyclic, MaxDistance, Random, SVRandom, UniformRandom, Quantile, SampledQuantile, WindowedQuantile
+from ._variants import (
+    Cyclic,
+    MaxDistance,
+    Quantile,
+    Random,
+    SampledQuantile,
+    SVRandom,
+    UniformRandom,
+    WindowedQuantile,
+)

--- a/src/kaczmarz/_abc.py
+++ b/src/kaczmarz/_abc.py
@@ -70,7 +70,9 @@ class Base(ABC):
 
     @property
     def ik(self):
-        """int: The index of the row used on the most recent iteration."""
+        """int: The index of the row used on the most recent iteration.
+
+        Takes the value -1 if a projection was not performed at iteration ``k``."""
         return self._ik
 
     @property
@@ -163,7 +165,9 @@ class Base(ABC):
 
         self._k += 1
         self._ik = self._select_row_index(self._xk)
-        self._xk = self._update_iterate(self._xk, self._ik)
+        if self._ik != -1:
+            self._xk = self._update_iterate(self._xk, self._ik)
+
         self._callback(self.xk)
 
         return self.xk

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -87,6 +87,23 @@ class UniformRandom(Random):
 
 
 class Quantile(Random):
+    """Reject equations whose normalized residual is above a quantile.
+
+    This algorithm is intended for use in solving corrupted systems of equations.
+    That is, systems where a subset of the equations are consistent,
+    while a minority of the equations are not.
+    Such systems are almost always overdetermined.
+
+    Parameters
+    ----------
+    quantile : float, optional
+        Quantile of normalized residual above which to reject.
+
+    References
+    ----------
+    1. There will be a reference soon. Keep an eye out for that.
+    """
+
     def __init__(self, *args, quantile=1.0, **kwargs):
         super().__init__(*args, **kwargs)
         self._quantile = quantile
@@ -115,6 +132,17 @@ class Quantile(Random):
 
 
 class SampledQuantile(Quantile):
+    """Reject equations whose normalized residual is above a quantile of a random subset of residual entries.
+
+    Parameters
+    ----------
+    n_samples: int, optional
+        Number of normalized residual samples used to compute the threshold quantile.
+
+    References
+    ----------
+    1. There will be a reference soon. Keep an eye out for that.
+    """
     def __init__(self, *args, n_samples=None, **kwargs):
         super().__init__(*args, **kwargs)
         if n_samples is None:
@@ -127,6 +155,21 @@ class SampledQuantile(Quantile):
 
 
 class WindowedQuantile(Quantile):
+    """Reject equations whose normalized residual is above a quantile of the most recent normalized residual values.
+
+    Parameters
+    ----------
+    window_size : int, optional
+        Number of recent normalized residual values used to compute the threshold quantile.
+
+    Note
+    ----
+    ``WindowedQuantile`` also accepts the parameters of ``Quantile``.
+
+    References
+    ----------
+    1. There will be a reference soon. Keep an eye out for that.
+    """
     def __init__(self, *args, window_size=None, **kwargs):
         super().__init__(*args, **kwargs)
         if window_size is None:

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -1,10 +1,10 @@
 """A module providing selection strategies for the Kaczmarz algorithm."""
 
+from collections import deque
+
 import numpy as np
 
 import kaczmarz
-
-from collections import deque
 
 
 class Cyclic(kaczmarz.Base):
@@ -87,10 +87,11 @@ class UniformRandom(Random):
 
 
 class ThresholdedBase(Random):
-
     def __init__(self, *base_args, **base_kwargs):
         super().__init__(*base_args, **base_kwargs)
-        self._most_recent_index = None  #Most recent index sampled, whether or not it met the threshold
+        self._most_recent_index = (
+            None  # Most recent index sampled, whether or not it met the threshold
+        )
 
     def _threshold(self):
         return
@@ -114,7 +115,7 @@ class ThresholdedBase(Random):
         if d < threshold or np.isclose(d, threshold):
             return ik
         else:
-            return -1 # No projection please
+            return -1  # No projection please
 
 
 class Quantile(ThresholdedBase):
@@ -145,8 +146,8 @@ class SampledQuantile(Quantile):
         idxs = np.random.choice(self._n_rows, self._n_samples, replace=False)
         return np.abs(self._b[idxs] - self._A[idxs] @ xk)
 
-class WindowedQuantile(Quantile):
 
+class WindowedQuantile(Quantile):
     def __init__(self, *args, window_size=100, **kwargs):
         super().__init__(*args, **kwargs)
         self._window_size = window_size
@@ -160,9 +161,9 @@ class WindowedQuantile(Quantile):
     def _select_row_index(self, xk):
         ik = super()._select_row_index(xk)
 
-        #is this really the right place to update the window?
+        # is this really the right place to update the window?
         self._update_window(xk, self._most_recent_index)
         return ik
 
-    def _distances(self, xk): #NOTE: xk is only here so that _distances is overridden
+    def _distances(self, xk):  # NOTE: xk is only here so that _distances is overridden
         return self._window

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -1,6 +1,7 @@
 """A module providing selection strategies for the Kaczmarz algorithm."""
 
 from collections import deque
+from abc import ABC, abstractmethod
 
 import numpy as np
 
@@ -86,15 +87,21 @@ class UniformRandom(Random):
     # Nothing to do since uniform sampling is the default behavior of Random.
 
 
-class ThresholdedBase(Random):
-    def __init__(self, *base_args, **base_kwargs):
-        super().__init__(*base_args, **base_kwargs)
-        self._most_recent_index = (
-            None  # Most recent index sampled, whether or not it met the threshold
-        )
-
+class ThresholdedBase(Random, ABC):
+    @abstractmethod
     def _threshold(self):
-        return
+        """Select a row to use for the next Kaczmarz update.
+
+        Parameters
+        ----------
+        xk : (n,) array
+            The current Kaczmarz iterate.
+
+        Returns
+        -------
+        ik : int
+            The index of the next row to use.
+        """
 
     def _distance(self, xk, ik):
         """

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -161,14 +161,9 @@ class WindowedQuantile(Quantile):
             window_size = self._n_rows
         self._window = deque([], maxlen=window_size)
 
-    def _select_row_index(self, xk):
-        ik = super()._select_row_index(xk)
-        self._window.append(self._most_recent_distance)
-        return ik
-
     def _distance(self, xk, ik):
         distance = super()._distance(xk, ik)
-        self._most_recent_distance = distance
+        self._window.append(distance)
         return distance
 
     def _distances(self, xk):

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -1,6 +1,5 @@
 """A module providing selection strategies for the Kaczmarz algorithm."""
 
-from abc import ABC, abstractmethod
 from collections import deque
 
 import numpy as np

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -155,22 +155,21 @@ class SampledQuantile(Quantile):
 
 
 class WindowedQuantile(Quantile):
-    def __init__(self, *args, window_size=100, **kwargs):
+    def __init__(self, *args, window_size=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self._window_size = window_size
-        self._window = deque([])
-
-    def _update_window(self, xk, ik):
-        self._window.append(self._distance(xk, ik))
-        if len(self._window) > self._window_size:
-            self._window.popleft()
+        if window_size is None:
+            window_size = self._n_rows
+        self._window = deque([], maxlen=window_size)
 
     def _select_row_index(self, xk):
         ik = super()._select_row_index(xk)
-
-        # is this really the right place to update the window?
-        self._update_window(xk, self._most_recent_index)
+        self._window.append(self._most_recent_distance)
         return ik
 
-    def _distances(self, xk):  # NOTE: xk is only here so that _distances is overridden
+    def _distance(self, xk, ik):
+        distance = super()._distance(xk, ik)
+        self._most_recent_distance = distance
+        return distance
+
+    def _distances(self, xk):
         return self._window

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -143,6 +143,7 @@ class SampledQuantile(Quantile):
     ----------
     1. There will be a reference soon. Keep an eye out for that.
     """
+
     def __init__(self, *args, n_samples=None, **kwargs):
         super().__init__(*args, **kwargs)
         if n_samples is None:
@@ -170,6 +171,7 @@ class WindowedQuantile(Quantile):
     ----------
     1. There will be a reference soon. Keep an eye out for that.
     """
+
     def __init__(self, *args, window_size=None, **kwargs):
         super().__init__(*args, **kwargs)
         if window_size is None:

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -115,14 +115,14 @@ class ThresholdedBase(Random, ABC):
         condition.  Otherwise returns -1.
         """
         ik = super()._select_row_index(xk)
-        self._most_recent_index = ik
 
-        d = self._distance(xk, ik)
+        distance = self._distance(xk, ik)
         threshold = self._threshold(xk)
-        if d < threshold or np.isclose(d, threshold):
+
+        if distance < threshold or np.isclose(distance, threshold):
             return ik
-        else:
-            return -1  # No projection please
+
+        return -1  # No projection please
 
 
 class Quantile(ThresholdedBase):

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -1,7 +1,7 @@
 """A module providing selection strategies for the Kaczmarz algorithm."""
 
-from collections import deque
 from abc import ABC, abstractmethod
+from collections import deque
 
 import numpy as np
 

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -94,14 +94,11 @@ class Quantile(Random):
     def _distance(self, xk, ik):
         return np.abs(self._b[ik] - self._A[ik] @ xk)
 
-    def _distances(self, xk):
+    def _threshold_distances(self, xk):
         return np.abs(self._b - self._A @ xk)
 
     def _threshold(self, xk):
-        distances = self._distances(xk)
-
-        if len(distances) == 0:
-            return 0
+        distances = self._threshold_distances(xk)
 
         return np.quantile(distances, self._quantile)
 
@@ -124,7 +121,7 @@ class SampledQuantile(Quantile):
             n_samples = self._n_rows
         self._n_samples = n_samples
 
-    def _distances(self, xk):
+    def _threshold_distances(self, xk):
         idxs = np.random.choice(self._n_rows, self._n_samples, replace=False)
         return np.abs(self._b[idxs] - self._A[idxs] @ xk)
 
@@ -141,5 +138,5 @@ class WindowedQuantile(Quantile):
         self._window.append(distance)
         return distance
 
-    def _distances(self, xk):
+    def _threshold_distances(self, xk):
         return self._window

--- a/tests/test_quantile_variants.py
+++ b/tests/test_quantile_variants.py
@@ -1,0 +1,62 @@
+import kaczmarz
+import numpy as np
+import pytest
+
+np.random.seed(0)
+
+quantile_strategies = []
+for name in dir(kaczmarz):
+    if name.startswith("_"):
+        continue
+    if "Quantile" not in name:
+        continue
+    attr = getattr(kaczmarz, name)
+    if attr == kaczmarz.Base:
+        continue
+    if not issubclass(attr, kaczmarz.Base):
+        continue
+    quantile_strategies.append(attr)
+
+def get_systems():
+    examples = []
+
+    A = np.arange(1, 11).reshape(-1, 1) # [[1], [2], ...]
+    x = np.array([1])
+    examples.append((A, x))
+
+    A = np.random.normal(size=(10, 2))
+    x = np.array([1, 1])
+    examples.append((A, x))
+
+    return examples
+
+class Sample100(kaczmarz.SampledQuantile):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, n_samples=10, **kwargs)
+
+class Window100(kaczmarz.WindowedQuantile):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, window_size=100, **kwargs)
+
+quantile_strategies.append(Sample100)
+quantile_strategies.append(Window100)
+
+@pytest.mark.parametrize("A,x_exact", get_systems())
+@pytest.mark.parametrize("QuantileStrategy", quantile_strategies)
+def test_corrupted_systems(A, x_exact, QuantileStrategy):
+    n_rows = A.shape[0]
+    maxiter = 100  # 100 iterations should be plenty for nice systems.
+    # TODO: Add a proper convergence criterion for corrupted systems.
+    row_norms = np.linalg.norm(A, axis=1)
+    b = A @ x_exact
+    b[0] += 100
+    x_approx = QuantileStrategy.solve(A, b, maxiter=maxiter, quantile=0.7)
+
+
+    residual = b - A @ x_approx
+
+    tol = 1e-5;
+
+    assert residual[0] > 99
+    assert np.linalg.norm(residual[1:]) < tol
+    # assert np.testing.assert_allclose(x_approx, x_exact, rtol=10 * tol)

--- a/tests/test_quantile_variants.py
+++ b/tests/test_quantile_variants.py
@@ -1,6 +1,7 @@
-import kaczmarz
 import numpy as np
 import pytest
+
+import kaczmarz
 
 np.random.seed(0)
 
@@ -17,10 +18,11 @@ for name in dir(kaczmarz):
         continue
     quantile_strategies.append(attr)
 
+
 def get_systems():
     examples = []
 
-    A = np.arange(1, 11).reshape(-1, 1) # [[1], [2], ...]
+    A = np.arange(1, 11).reshape(-1, 1)  # [[1], [2], ...]
     x = np.array([1])
     examples.append((A, x))
 
@@ -30,33 +32,33 @@ def get_systems():
 
     return examples
 
+
 class Sample100(kaczmarz.SampledQuantile):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, n_samples=10, **kwargs)
+
 
 class Window100(kaczmarz.WindowedQuantile):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, window_size=100, **kwargs)
 
+
 quantile_strategies.append(Sample100)
 quantile_strategies.append(Window100)
+
 
 @pytest.mark.parametrize("A,x_exact", get_systems())
 @pytest.mark.parametrize("QuantileStrategy", quantile_strategies)
 def test_corrupted_systems(A, x_exact, QuantileStrategy):
-    n_rows = A.shape[0]
     maxiter = 100  # 100 iterations should be plenty for nice systems.
     # TODO: Add a proper convergence criterion for corrupted systems.
-    row_norms = np.linalg.norm(A, axis=1)
     b = A @ x_exact
     b[0] += 100
     x_approx = QuantileStrategy.solve(A, b, maxiter=maxiter, quantile=0.7)
 
-
     residual = b - A @ x_approx
 
-    tol = 1e-5;
+    tol = 1e-5
 
     assert residual[0] > 99
     assert np.linalg.norm(residual[1:]) < tol
-    # assert np.testing.assert_allclose(x_approx, x_exact, rtol=10 * tol)

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -4,6 +4,8 @@ import scipy.sparse as sp
 
 import kaczmarz
 
+np.random.seed(0)
+
 strategies = []
 for name in dir(kaczmarz):
     if name.startswith("_"):

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ commands =
     python -m pytest --basetemp={envtmpdir} \
                      --cov-report=term-missing \
                      --cov=kaczmarz \
-                     --verbose \
                      tests/
 
 


### PR DESCRIPTION
There are several proposed variants of Kaczmarz which sample only rows whose residual is **below** some threshold. This is useful when data could be corrupted in a small number of measurements.