### PR TITLE
Added Lookahead variant for a 2-step lookahead

### DIFF
--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -15,6 +15,7 @@ from ._abc import Base
 from ._variants import (
     Cyclic,
     MaxDistance,
+    Lookahead,
     Quantile,
     Random,
     RandomOrthoGraph,

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -14,7 +14,7 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 from ._abc import Base
 from ._variants import (
     Cyclic,
-    Lookahead,
+    MaxDistanceLookahead,
     MaxDistance,
     Quantile,
     Random,

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -14,8 +14,8 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 from ._abc import Base
 from ._variants import (
     Cyclic,
-    MaxDistanceLookahead,
     MaxDistance,
+    MaxDistanceLookahead,
     Quantile,
     Random,
     RandomOrthoGraph,

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -14,8 +14,8 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 from ._abc import Base
 from ._variants import (
     Cyclic,
-    MaxDistance,
     Lookahead,
+    MaxDistance,
     Quantile,
     Random,
     RandomOrthoGraph,

--- a/src/kaczmarz/_utils.py
+++ b/src/kaczmarz/_utils.py
@@ -2,14 +2,19 @@ from scipy import sparse
 
 
 def scale_rows(A, v):
+    """Scale each row of A by the corresponding entry of v and return the
+    result."""
     return sparse.spdiags(v, 0, len(v), len(v)) @ A
 
 
 def scale_cols(A, v):
+    """Scale each column of A by the corresponding entry of v and return the
+    result."""
     return A @ sparse.spdiags(v, 0, len(v), len(v))
 
 
 def square(A):
+    """Return the product of A with itself."""
     if sparse.issparse(A):
         return A.power(2)
     return A ** 2

--- a/src/kaczmarz/_utils.py
+++ b/src/kaczmarz/_utils.py
@@ -1,0 +1,15 @@
+from scipy import sparse
+
+
+def scale_rows(A, v):
+    return sparse.spdiags(v, 0, len(v), len(v)) @ A
+
+
+def scale_cols(A, v):
+    return A @ sparse.spdiags(v, 0, len(v), len(v))
+
+
+def square(A):
+    if sparse.issparse(A):
+        return A.power(2)
+    return A ** 2

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -31,7 +31,7 @@ class Cyclic(kaczmarz.Base):
         return self._row_index
 
 
-class Lookahead(kaczmarz.Base):
+class MaxDistanceLookahead(kaczmarz.Base):
     """Choose equations which lead to the most progress after a 2 step lookahead
     """
 

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -4,7 +4,20 @@ from collections import deque
 
 import numpy as np
 
+from scipy import sparse
+
 import kaczmarz
+
+def scale_rows(A, v):
+    return sparse.spdiags(v, 0, len(v), len(v)) @ A
+
+def scale_cols(A, v):
+    return A @ sparse.spdiags(v, 0, len(v), len(v))
+
+def square(A):
+    if sparse.issparse(A):
+        return A.power(2)
+    return A**2
 
 
 class Cyclic(kaczmarz.Base):
@@ -36,28 +49,27 @@ class Lookahead(kaczmarz.Base):
     def __init__(self, *base_args, **base_kwargs):
         super().__init__(*base_args, **base_kwargs)
         self._next_i = None
+        self._gram = self._A @ self._A.T
+        self._gram2 = square(self._gram)
+
 
     def _select_row_index(self, xk):
         if self._next_i is not None:
             temp = self._next_i
             self._next_i = None
             return temp
-        best_i = -1
-        self._next_i = -1
-        best_residual_norms = (float("inf"), float("inf"))
-        for ik in range(self._n_rows):
-            next_xk = self._update_iterate(self._xk, ik)
-            residual = self._b - self._A @ next_xk
-            ik2 = np.argmax(np.abs(residual))
-            next_next_xk = self._update_iterate(next_xk, ik2)
-            next_residual_norm = np.linalg.norm(self._b - self._A @ next_next_xk)
-            residual_norms = (next_residual_norm, np.linalg.norm(residual))
-            if residual_norms < best_residual_norms:
-                best_i = ik
-                self._next_i = ik2
-                best_residual_norms = residual_norms
-        return best_i
 
+        residual = self._b - self._A @ xk
+        residual_2 = np.square(residual)
+        cost_mat = np.array(residual_2[:, None] + residual_2[None, :] -\
+            2 * scale_rows(scale_cols(self._gram, residual), residual) +\
+            scale_rows(self._gram2, residual_2))
+        best_cost = np.max(cost_mat)
+
+        sort_idxs = np.argsort(residual_2)[::-1]
+        best_i = sort_idxs[np.any(cost_mat[sort_idxs,:]==best_cost, axis=1)][0]
+        self._next_i = np.argwhere(cost_mat[best_i] == best_cost)[0][0]
+        return best_i
 
 class MaxDistance(kaczmarz.Base):
     """Choose equations which leads to the most progress.

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -6,20 +6,7 @@ import numpy as np
 from scipy import sparse
 
 import kaczmarz
-
-
-def scale_rows(A, v):
-    return sparse.spdiags(v, 0, len(v), len(v)) @ A
-
-
-def scale_cols(A, v):
-    return A @ sparse.spdiags(v, 0, len(v), len(v))
-
-
-def square(A):
-    if sparse.issparse(A):
-        return A.power(2)
-    return A ** 2
+from ._utils import scale_rows, scale_cols, square
 
 
 class Cyclic(kaczmarz.Base):

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -38,8 +38,8 @@ class MaxDistanceLookahead(kaczmarz.Base):
     def __init__(self, *base_args, **base_kwargs):
         super().__init__(*base_args, **base_kwargs)
         self._next_i = None
-        self._gram = self._A @ self._A.T
-        self._gram2 = square(self._gram)
+        self._gramian = self._A @ self._A.T
+        self._gramian2 = square(self._gramian)
 
     def _select_row_index(self, xk):
         if self._next_i is not None:
@@ -52,8 +52,8 @@ class MaxDistanceLookahead(kaczmarz.Base):
         cost_mat = np.array(
             residual_2[:, None]
             + residual_2[None, :]
-            - 2 * scale_rows(scale_cols(self._gram, residual), residual)
-            + scale_rows(self._gram2, residual_2)
+            - 2 * scale_rows(scale_cols(self._gramian, residual), residual)
+            + scale_rows(self._gramian2, residual_2)
         )
         best_cost = np.max(cost_mat)
 

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -33,8 +33,7 @@ class Cyclic(kaczmarz.Base):
 
 
 class MaxDistanceLookahead(kaczmarz.Base):
-    """Choose equations which lead to the most progress after a 2 step lookahead
-    """
+    """Choose equations which lead to the most progress after a 2 step lookahead"""
 
     def __init__(self, *base_args, **base_kwargs):
         super().__init__(*base_args, **base_kwargs)

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -3,21 +3,23 @@
 from collections import deque
 
 import numpy as np
-
 from scipy import sparse
 
 import kaczmarz
 
+
 def scale_rows(A, v):
     return sparse.spdiags(v, 0, len(v), len(v)) @ A
+
 
 def scale_cols(A, v):
     return A @ sparse.spdiags(v, 0, len(v), len(v))
 
+
 def square(A):
     if sparse.issparse(A):
         return A.power(2)
-    return A**2
+    return A ** 2
 
 
 class Cyclic(kaczmarz.Base):
@@ -52,7 +54,6 @@ class Lookahead(kaczmarz.Base):
         self._gram = self._A @ self._A.T
         self._gram2 = square(self._gram)
 
-
     def _select_row_index(self, xk):
         if self._next_i is not None:
             temp = self._next_i
@@ -61,15 +62,19 @@ class Lookahead(kaczmarz.Base):
 
         residual = self._b - self._A @ xk
         residual_2 = np.square(residual)
-        cost_mat = np.array(residual_2[:, None] + residual_2[None, :] -\
-            2 * scale_rows(scale_cols(self._gram, residual), residual) +\
-            scale_rows(self._gram2, residual_2))
+        cost_mat = np.array(
+            residual_2[:, None]
+            + residual_2[None, :]
+            - 2 * scale_rows(scale_cols(self._gram, residual), residual)
+            + scale_rows(self._gram2, residual_2)
+        )
         best_cost = np.max(cost_mat)
 
         sort_idxs = np.argsort(residual_2)[::-1]
-        best_i = sort_idxs[np.any(cost_mat[sort_idxs,:]==best_cost, axis=1)][0]
+        best_i = sort_idxs[np.any(cost_mat[sort_idxs, :] == best_cost, axis=1)][0]
         self._next_i = np.argwhere(cost_mat[best_i] == best_cost)[0][0]
         return best_i
+
 
 class MaxDistance(kaczmarz.Base):
     """Choose equations which leads to the most progress.

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -29,26 +29,8 @@ class Cyclic(kaczmarz.Base):
         return self._row_index
 
 
-class MaxDistance(kaczmarz.Base):
-    """Choose equations which leads to the most progress.
-
-    This selection strategy is also known as `Motzkin's method`.
-
-    References
-    ----------
-    1. T. S. Motzkin and I. J. Schoenberg.
-       "The relaxation method for linear inequalities."
-       *Canadian Journal of Mathematics*, 6:393–404, 1954.
-    """
-
-    def _select_row_index(self, xk):
-        # TODO: use auxiliary update for the residual.
-        residual = self._b - self._A @ self._xk
-        return np.argmax(np.abs(residual))
-
-
 class Lookahead(kaczmarz.Base):
-    """Choose equations which leads to the most progress after a 2 step lookahead
+    """Choose equations which lead to the most progress after a 2 step lookahead
     """
 
     def __init__(self, *base_args, **base_kwargs):
@@ -75,6 +57,24 @@ class Lookahead(kaczmarz.Base):
                 self._next_i = ik2
                 best_residual_norms = residual_norms
         return best_i
+
+
+class MaxDistance(kaczmarz.Base):
+    """Choose equations which leads to the most progress.
+
+    This selection strategy is also known as `Motzkin's method`.
+
+    References
+    ----------
+    1. T. S. Motzkin and I. J. Schoenberg.
+       "The relaxation method for linear inequalities."
+       *Canadian Journal of Mathematics*, 6:393–404, 1954.
+    """
+
+    def _select_row_index(self, xk):
+        # TODO: use auxiliary update for the residual.
+        residual = self._b - self._A @ self._xk
+        return np.argmax(np.abs(residual))
 
 
 class Random(kaczmarz.Base):

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -33,7 +33,7 @@ class Cyclic(kaczmarz.Base):
 
 
 class MaxDistanceLookahead(kaczmarz.Base):
-    """Choose equations which lead to the most progress after a 2 step lookahead"""
+    """Choose equations which lead to the most progress after a 2 step lookahead."""
 
     def __init__(self, *base_args, **base_kwargs):
         super().__init__(*base_args, **base_kwargs)

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -6,7 +6,8 @@ import numpy as np
 from scipy import sparse
 
 import kaczmarz
-from ._utils import scale_rows, scale_cols, square
+
+from ._utils import scale_cols, scale_rows, square
 
 
 class Cyclic(kaczmarz.Base):

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -47,6 +47,7 @@ def test_simple_cases():
     next(iterator)
     assert 1 == iterates.ik
 
+
 def test_lookahead_case():
     A = [
         [1, 0],

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -11,7 +11,7 @@ def test_simple_cases():
     ]
     b = [1, 2, 3]
     x0 = [0, 0, 0]
-    iterator = iter(kaczmarz.Lookahead.iterates(A, b, x0))
+    iterator = iter(kaczmarz.MaxDistanceLookahead.iterates(A, b, x0))
     assert [0, 0, 0] == list(next(iterator))
     assert [0, 0, 3] == list(next(iterator))
     assert [0, 2, 3] == list(next(iterator))
@@ -26,7 +26,7 @@ def test_simple_cases():
     ]
     b = [1, 1, 1]
     x0 = [0, 0, 0]
-    iterator = iter(kaczmarz.Lookahead.iterates(A, b, x0))
+    iterator = iter(kaczmarz.MaxDistanceLookahead.iterates(A, b, x0))
     assert [0, 0, 0] == list(next(iterator))
     assert [1, 0, 0] == list(next(iterator))
     assert [1, 0.5, 0] == list(next(iterator))
@@ -41,7 +41,7 @@ def test_simple_cases():
     ]
     b = [3, 4, 3]
     x0 = [1, 1, 1]
-    iterates = kaczmarz.Lookahead.iterates(A, b, x0)
+    iterates = kaczmarz.MaxDistanceLookahead.iterates(A, b, x0)
     iterator = iter(iterates)
     next(iterator)
     next(iterator)
@@ -56,7 +56,7 @@ def test_lookahead_case():
     ]
     b = [0, 0, 0]
     x0 = [1, -0.5]
-    iterates = kaczmarz.Lookahead.iterates(A, b, x0)
+    iterates = kaczmarz.MaxDistanceLookahead.iterates(A, b, x0)
     iterator = iter(iterates)
     assert [1, -0.5] == list(next(iterator))
     assert [0, -0.5] == list(next(iterator))

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -1,0 +1,62 @@
+import pytest
+
+import kaczmarz
+
+
+def test_simple_cases():
+    A = [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+    ]
+    b = [1, 2, 3]
+    x0 = [0, 0, 0]
+    iterator = iter(kaczmarz.Lookahead.iterates(A, b, x0))
+    assert [0, 0, 0] == list(next(iterator))
+    assert [0, 0, 3] == list(next(iterator))
+    assert [0, 2, 3] == list(next(iterator))
+    assert [1, 2, 3] == list(next(iterator))
+    with pytest.raises(StopIteration):
+        next(iterator)
+
+    A = [
+        [1, 0, 0],
+        [0, 2, 0],
+        [0, 0, 4],
+    ]
+    b = [1, 1, 1]
+    x0 = [0, 0, 0]
+    iterator = iter(kaczmarz.Lookahead.iterates(A, b, x0))
+    assert [0, 0, 0] == list(next(iterator))
+    assert [1, 0, 0] == list(next(iterator))
+    assert [1, 0.5, 0] == list(next(iterator))
+    assert [1, 0.5, 0.25] == list(next(iterator))
+    with pytest.raises(StopIteration):
+        next(iterator)
+
+    A = [
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+    ]
+    b = [3, 4, 3]
+    x0 = [1, 1, 1]
+    iterates = kaczmarz.Lookahead.iterates(A, b, x0)
+    iterator = iter(iterates)
+    next(iterator)
+    next(iterator)
+    assert 1 == iterates.ik
+
+def test_lookahead_case():
+    A = [
+        [1, 0],
+        [0, 1],
+        [1, -1],
+    ]
+    b = [0, 0, 0]
+    x0 = [1, -0.5]
+    iterates = kaczmarz.Lookahead.iterates(A, b, x0)
+    iterator = iter(iterates)
+    assert [1, -0.5] == list(next(iterator))
+    assert [0, -0.5] == list(next(iterator))
+    assert [0, 0] == list(next(iterator))


### PR DESCRIPTION
Added a Kaczmarz variant for a 2-step lookahead. Extremely computationally inefficient, only to be used for small cases.